### PR TITLE
Error in makefile generation (both in base repo and in the C templates)

### DIFF
--- a/configure
+++ b/configure
@@ -34,4 +34,4 @@ case "$OVERRIDE" in
 esac
 
 echo "Using $CC as the compiler"
-echo -e "INSTALL_DIR:=/usr/local/bin\n\npi:\n\t$CC -I include src/**/*.c src/pi.c -o pi\n\n.PHONY: install\ninstall: pi\n\tinstall -m 755 pi ${INSTALL_DIR}" > Makefile
+echo -e "INSTALL_DIR:=/usr/local/bin\n\npi:\n\t$CC -I include src/**/*.c src/pi.c -o pi\n\n.PHONY: install\ninstall: pi\n\tinstall -m 755 pi \${INSTALL_DIR}" > Makefile

--- a/src/libs/lang_scripts.c
+++ b/src/libs/lang_scripts.c
@@ -117,7 +117,7 @@ case \"$OVERRIDE\" in\n\
 esac\n\
 \n\
 echo \"Using $CC as the compiler\"\n\
-echo -e \"INSTALL_DIR:=/usr/local/bin\n\n%s:\n\t$CC -I include src/**/*.c src/%s.c -o %s\n\n.PHONY: install\ninstall: %s\n\tinstall -m 755 %s ${INSTALL_DIR}\" > Makefile\n"
+echo -e \"INSTALL_DIR:=/usr/local/bin\\n\\n%s:\\n\\t$CC -I include src/**/*.c src/%s.c -o %s\\n\\n.PHONY: install\\ninstall: %s\\n\\tinstall -m 755 %s \\${INSTALL_DIR}\" > Makefile\n"
 #define CPP_CONFIGURE_DEFAULT "\
 #!/bin/bash\n\
 \n\


### PR DESCRIPTION
Makefiles were being generated without `${INSTALL_DIR}` in them due to a missing escape char.

Also added escape chars for consistency and brevity in configure scripts.