### PR TITLE
Bug with Rust solution

### DIFF
--- a/src/libs/lang_scripts.c
+++ b/src/libs/lang_scripts.c
@@ -427,7 +427,7 @@ int rust_init(char *name, char* args) {
     return simple_init(
         name, 
         args, 
-        "cargo new %s", 
+        "cargo init", 
         "Rust"
     );
 }


### PR DESCRIPTION
`cargo new` was making a subdirectory because I meant `cargo init`