### PR TITLE
Fixed segfault in simple_init()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # executable shouldn't be in the repo
 pi
-pi_*
+pi*
 
 # no coredumps please lol
 CORE-*

--- a/src/libs/lang_scripts.c
+++ b/src/libs/lang_scripts.c
@@ -208,7 +208,7 @@ int simple_init(char *name, char* args, char* cmd, char* langstr) {
     printf("\x1b[0;90mInitializing %s project \x1b[0;1;33m%s\x1b[0;90m...\x1b[0m\n", langstr, name);
     char* str = malloc(512);
     if (args) {
-        strcat(cmd, " %s");
+        strcat(cmd, " %%s");     // missing % here caused a segfault (20240703)
         snprintf(str, 512, cmd, name, args);
     } else {
         snprintf(str, 512, cmd, name);

--- a/src/libs/lang_scripts.c
+++ b/src/libs/lang_scripts.c
@@ -4,6 +4,7 @@
  *  This file is part of the `pi` project.
  *  `pi` is licensed under the MIT license.
  *  Please see the LICENSE file for more information.
+ *  Copyright (c) 2024 uptu
  */
 
 // * Table of Contents

--- a/src/pi.c
+++ b/src/pi.c
@@ -4,10 +4,11 @@
  *  This file is part of the `pi` project.
  *  `pi` is licensed under the MIT license.
  *  Please see the LICENSE file for more information.
+ *  Copyright (c) 2024 uptu
  */
 
-#include "input_handler.h"
-#include "lang_scripts.h"
+#include "./input_handler.h"
+#include "./lang_scripts.h"
 
 void free_project(struct Project* project) {
     if (!(project->stack_arg_flags & 1)) {
@@ -17,7 +18,7 @@ void free_project(struct Project* project) {
     if (!(project->stack_arg_flags & 2)) {
         free(project->lang);
     }
-    
+
     if (!(project->stack_arg_flags & 4)) {
         free(project->init_args);
     }
@@ -38,13 +39,16 @@ int main(int argc, char** argv) {
      *  If the language is supported, run the appropriate initialization function.
      */
     int res = route(parsed.name, parsed.lang, parsed.init_args);
-    char* name = parsed.name ? strcpy(malloc(length(parsed.name) + 1), parsed.name) : (void*)0;
+    char* name = parsed.name ?
+        strcpy(malloc(length(parsed.name) + 1), parsed.name)
+        : NULL;
 
-    // If the initialization function returns `1`, the router has to re-route a new response
+    // If the initialization function returns `1`,
+    // the router has to re-route a new response
     while (res == 1) {
         free_project(&parsed);
         parsed = handle(0, &name);
-        res = route(parsed.name, parsed.lang, parsed.init_args);    
+        res = route(parsed.name, parsed.lang, parsed.init_args);
     }
 
     /*


### PR DESCRIPTION
* `simple_init()` had the following erroneous segment while constructing a
  format string:

    ```c
    char* str = malloc(512);
    if (args) {
        strcat(cmd, " %s");
        snprintf(str, 512, cmd, name, args);
    } else {
        snprintf(str, 512, cmd, name);
    }
    ```

Note that the strcat call includes an unescaped % symbol, which must be
escaped via `" %%s"`